### PR TITLE
rename snapshot path to ~/.aragon/aragen-db-{version}

### DIFF
--- a/src/commands/devchain.js
+++ b/src/commands/devchain.js
@@ -53,7 +53,7 @@ exports.task = async function({
 
   const snapshotPath = path.join(
     os.homedir(),
-    `.aragon/ganache-db-${pjson.version}`
+    `.aragon/aragen-db-${pjson.version}`
   )
 
   const tasks = new TaskList(


### PR DESCRIPTION
closes #39 