### PR TITLE
Patch release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/aragen",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Generate Aragon local dev environment snapshots",
   "main": "index.js",
   "bin": {
@@ -41,7 +41,7 @@
   },
   "homepage": "https://github.com/aragon/aragen#readme",
   "dependencies": {
-    "@aragon/cli-utils": "^0.0.6",
+    "@aragon/cli-utils": "^0.0.8",
     "@babel/polyfill": "^7.0.0",
     "chalk": "^2.1.0",
     "execa": "^2.0.3",


### PR DESCRIPTION
Fix an issue when creating a new dao with the `bare-templates`:

```
❯ Create DAO
    ✖ Create new DAO from template
      → Cannot read property 'returnValues' of undefined
```