### PR TITLE
Utilize the "next" branch of open-enterprise

### DIFF
--- a/scripts/get-repos/open-enterprise
+++ b/scripts/get-repos/open-enterprise
@@ -5,7 +5,7 @@ set -e;
 echo "Fetching planning-suite and installing dependencies (this may take a while 😉)"
 
 cd repos;
-git clone https://github.com/AutarkLabs/open-enterprise.git -b dev;
+git clone https://github.com/AutarkLabs/open-enterprise.git -b next;
 cd open-enterprise;
 npm run bootstrap -- --no-ci;
 cd ..;


### PR DESCRIPTION
Now that we're releasing regularly to rinkeby, we've created a "next" branch for our stable rinkeby releases. "dev" is now more of a nightly branch, which might lead to some unfortunate devX.