### PR TITLE
Publish client from public folder

### DIFF
--- a/scripts/publish/client
+++ b/scripts/publish/client
@@ -11,4 +11,4 @@ cd repos/aragon;
 
 npm run build:local;
 
-aragon apm publish 1.0.0 --only-content --files build --publish-dir $IPFS_CACHE/@aragon/aragon --skip-confirmation --no-propagate-content --no-build;
+aragon apm publish 1.0.0 --only-content --files public --publish-dir $IPFS_CACHE/@aragon/aragon --skip-confirmation --no-propagate-content --no-build;


### PR DESCRIPTION
- Fixes #101 

The Aragon client now outputs its files to the `public` folder instead of `build`.